### PR TITLE
Add support for Backend HTTP listener and health probe host name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ http_listeners = [
   - `enable_cookie_based_affinity`: Keep a user session on the same server. This will direct subsequent traffic from a user session to the same server for processing.
   - `request_timeout`: Maximum time in seconds to wait for a response which must be between 1 and 86400 seconds.
   - `probe_name`: Name of an associated HTTP probe. Set to `null` if no custom health probe is needed.
+  - `host_name`: Host header to be sent to the backend servers. Should be set to `null` if `pick_host_name_from_backend_address` is set to true
+  - `pick_host_name_from_backend_address`: Whether host header should be picked from the host name of the backend server.
 
 Example:
 
@@ -96,6 +98,8 @@ Example:
   - `unhealthy_threshold`: The Unhealthy Threshold for this Probe, which indicates the amount of retries which should be attempted before a node is deemed unhealthy. Possible values are from 1 - 20 seconds.
   - `match_body`: A snippet from the response body which must be present for the probe target to be considered healthy
   - `match_status_codes`: A list of status codes from the request response that indicate a probe target is healthy
+  - `pick_host_name_from_backend_http_settings`: Whether the host header should be picked from the backend http settings.
+  - `host`: The Hostname used for this Probe. If the Application Gateway is configured for a single site, by default the Host name should be specified as ‘127.0.0.1’, unless otherwise configured in custom probe. Should be set to `null` if `pick_host_name_from_backend_http_settings` is set to `true`.
 
 Example:
 

--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,8 @@ resource "azurerm_application_gateway" "main" {
       protocol                            = backend_http_settings.value.protocol
       request_timeout                     = backend_http_settings.value.request_timeout
       probe_name                          = backend_http_settings.value.probe_name
-      pick_host_name_from_backend_address = true
+      host_name                           = backend_http_settings.value.host_name
+      pick_host_name_from_backend_address = backend_http_settings.value.pick_host_name_from_backend_address
     }
   }
   dynamic "probe" {
@@ -149,7 +150,7 @@ resource "azurerm_application_gateway" "main" {
         status_code  = probe.value.match_status_codes
       }
 
-      pick_host_name_from_backend_http_settings = true
+      pick_host_name_from_backend_http_settings = probe.value.pick_host_name_from_backend_http_settings
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,13 +65,15 @@ variable "backend_address_pools" {
 variable "backend_http_settings" {
   description = "List of backend HTTP settings."
   type = list(object({
-    name                         = string
-    path                         = string
-    port                         = number
-    protocol                     = string
-    enable_cookie_based_affinity = bool
-    request_timeout              = number
-    probe_name                   = string
+    name                                = string
+    path                                = string
+    port                                = number
+    protocol                            = string
+    enable_cookie_based_affinity        = bool
+    request_timeout                     = number
+    probe_name                          = string
+    host_name                           = string
+    pick_host_name_from_backend_address = bool
   }))
 }
 
@@ -79,14 +81,15 @@ variable "probes" {
   description = "Health probes used to test backend health."
   default     = []
   type = list(object({
-    name                = string
-    path                = string
-    protocol            = string
-    interval            = number
-    timeout             = number
-    unhealthy_threshold = number
-    match_body          = string
-    match_status_codes  = list(string)
+    name                                      = string
+    path                                      = string
+    protocol                                  = string
+    interval                                  = number
+    timeout                                   = number
+    unhealthy_threshold                       = number
+    match_body                                = string
+    match_status_codes                        = list(string)
+    pick_host_name_from_backend_http_settings = bool
   }))
 }
 


### PR DESCRIPTION
# Changes

- Add `host_name` & `pick_host_name_from_*` configuration to the variables files
- Update README